### PR TITLE
Fix typo in api docs

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -124,7 +124,7 @@ impl PublicApi {
 
     /// Returns the following anchoring address if the node is in a transition state.
     ///
-    /// `GET /{api_prefix}/v1/address/actual`
+    /// `GET /{api_prefix}/v1/address/following`
     pub fn following_address(&self) -> Result<Option<btc::Address>, ApiError> {
         let snapshot = self.blockchain.snapshot();
         let schema = AnchoringSchema::new(snapshot);


### PR DESCRIPTION
This merge fixes typo in `PublicApi` documentation.